### PR TITLE
fix: Fix memory leak issue in screen.capture() [Linux]

### DIFF
--- a/src/linux/xorg.rs
+++ b/src/linux/xorg.rs
@@ -1,6 +1,10 @@
-use crate::{Image, Screen};
 use std::{ptr, slice};
-use x11::xlib::{XAllPlanes, XCloseDisplay, XDefaultRootWindow, XGetImage, XOpenDisplay, ZPixmap};
+
+use x11::xlib::{
+  XAllPlanes, XCloseDisplay, XDefaultRootWindow, XDestroyImage, XGetImage, XOpenDisplay, ZPixmap,
+};
+
+use crate::{Image, Screen};
 
 fn capture(x: i32, y: i32, width: u32, height: u32) -> Option<Image> {
   unsafe {
@@ -36,6 +40,8 @@ fn capture(x: i32, y: i32, width: u32, height: u32) -> Option<Image> {
       data as *mut u8,
       (width * height * 4) as usize,
     ));
+
+    XDestroyImage(ximage);
 
     match Image::from_bgra(width as u32, height as u32, bytes) {
       Ok(image) => Some(image),


### PR DESCRIPTION
`XImage` pointer was not being released at the end of the function.

I've found the following function which seems to have solved the issue:
https://tronche.com/gui/x/xlib/utilities/XDestroyImage.html

The following test script was used. It does not keep consuming memory anymore, so I think the issue is solved.
https://gist.github.com/mdacach/3ccc93751af3ee125739b2f994b85e03

P.S. I've found a simple `XFree(data as *mut _)` to also solve the issue, which I don't fully understand because the image pointer would still leak, I think.