### PR TITLE
Change from sfhash to fxhash 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,14 +12,14 @@ keywords = ["screenshots", "screenshot", "screen", "capture"]
 
 [dependencies]
 png = "0.17.7"
-display-info = "0.4.0"
+display-info = {git = "https://github.com/Olssdani/display-info"}
 anyhow = "1.0.69"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 core-graphics = "0.22.3"
 
 [target.'cfg(target_os="windows")'.dependencies]
-sfhash = "0.1.1"
+fxhash = "0.2.1"
 widestring = "1.0.2"
 
 [target.'cfg(target_os = "windows")'.dependencies.windows]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["screenshots", "screenshot", "screen", "capture"]
 
 [dependencies]
 png = "0.17.7"
-display-info = {git = "https://github.com/Olssdani/display-info"}
+display-info = "0.4.0"
 anyhow = "1.0.69"
 
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/src/win32.rs
+++ b/src/win32.rs
@@ -1,6 +1,5 @@
 use crate::{DisplayInfo, Image};
 use anyhow::{anyhow, Result};
-use sfhash::digest;
 use std::{mem, ops::Deref, ptr};
 use widestring::U16CString;
 use windows::{
@@ -70,7 +69,7 @@ fn get_monitor_info_exw_from_id(id: u32) -> Result<MONITORINFOEXW> {
     .find(|&&monitor_info_exw| {
       let sz_device_ptr = monitor_info_exw.szDevice.as_ptr();
       let sz_device_string = unsafe { U16CString::from_ptr_str(sz_device_ptr).to_string_lossy() };
-      digest(sz_device_string.as_bytes()) == id
+      fxhash::hash32(sz_device_string.as_bytes()) == id
     })
     .ok_or_else(|| anyhow!("Get monitor info exw failed"))?;
 


### PR DESCRIPTION
Changed from sfhash to fxhash because of license issue.

sfhash has LGPL license which conflicts with the Apache-2.0 license

It is depended on the PR I did in display-info. https://github.com/nashaofu/display-info/pull/14 