### PR TITLE
support wlroots based compositors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,4 +29,5 @@ features = ["Win32_Foundation", "Win32_Graphics_Gdi"]
 
 [target.'cfg(target_os="linux")'.dependencies]
 dbus = { version = "0.9.7", features = ["vendored"] }
+libwayshot = "0.2"
 xcb = "1.2.1"


### PR DESCRIPTION
Use [libwayshot](https://crates.io/crates/libwayshot) to get a screenshot using the wlroots protocol. This is required for the library to work on [sway](https://swaywm.org/) for example.

Currently it only tries it if all other methods fail, but it could be possible to detect if wlroots is being used and therefore try it first.