### PR TITLE
Improve capture performance on macOS

### DIFF
--- a/src/darwin.rs
+++ b/src/darwin.rs
@@ -20,6 +20,7 @@ fn capture(display_info: &DisplayInfo, cg_rect: CGRect) -> Result<RgbaImage> {
     let height = cg_image.height();
     let clean_buf = remove_extra_data(
         width,
+        height,
         cg_image.bytes_per_row(),
         Vec::from(cg_image.data().bytes()),
     );

--- a/src/image_utils.rs
+++ b/src/image_utils.rs
@@ -7,13 +7,14 @@ pub fn vec_to_rgba_image(width: u32, height: u32, buf: Vec<u8>) -> Result<RgbaIm
 
 #[cfg(any(target_os = "windows", target_os = "macos", test))]
 pub fn bgra_to_rgba_image(width: u32, height: u32, buf: Vec<u8>) -> Result<RgbaImage> {
-    // convert to rgba
-    let rgba_buf = buf
-        .chunks_exact(4)
-        .take((width * height) as usize)
-        .flat_map(|bgra| [bgra[2], bgra[1], bgra[0], bgra[3]])
-        .collect();
+    let mut rgba_buf = buf.clone();
 
+    for (src, dst) in buf.chunks_exact(4).zip(rgba_buf.chunks_exact_mut(4)) {
+        dst[0] = src[2];
+        dst[1] = src[1];
+        dst[2] = src[0];
+        dst[3] = src[3];
+    }
     vec_to_rgba_image(width, height, rgba_buf)
 }
 

--- a/src/image_utils.rs
+++ b/src/image_utils.rs
@@ -24,10 +24,19 @@ pub fn bgra_to_rgba_image(width: u32, height: u32, buf: Vec<u8>) -> Result<RgbaI
 /// https://github.com/nashaofu/screenshots-rs/issues/29
 /// https://github.com/nashaofu/screenshots-rs/issues/38
 #[cfg(any(target_os = "macos", test))]
-pub fn remove_extra_data(width: usize, bytes_per_row: usize, buf: Vec<u8>) -> Vec<u8> {
-    buf.chunks_exact(bytes_per_row)
-        .flat_map(|row| row.split_at(width * 4).0.to_owned())
-        .collect()
+pub fn remove_extra_data(
+    width: usize,
+    height: usize,
+    bytes_per_row: usize,
+    buf: Vec<u8>,
+) -> Vec<u8> {
+    let extra_bytes_per_row = bytes_per_row - width * 4;
+    let mut result = Vec::with_capacity(buf.len() - extra_bytes_per_row * height);
+    for row in buf.chunks_exact(bytes_per_row) {
+        result.extend_from_slice(&row[..width * 4]);
+    }
+
+    result
 }
 
 #[cfg(any(target_os = "linux", test))]
@@ -61,6 +70,7 @@ mod tests {
     #[test]
     fn extra_data() {
         let clean = remove_extra_data(
+            2,
             2,
             9,
             vec![


### PR DESCRIPTION
Captures were really slow for me on macOS(>1s) for a full-screen capture.

cargo-flamegraph showed that most of the time was being spent in `bgra_to_rgba_image` and `remove_extra_data` because they were spending time extending the buffer as items were being added.  I have made changes so that buffers being returned are pre-allocated.

Before:
<img width="1503" alt="Screenshot 2023-12-15 at 08 40 06" src="https://github.com/nashaofu/screenshots-rs/assets/480806/7e901d32-c2c3-49db-8d87-830528a189a8">

After:
<img width="1501" alt="Screenshot 2023-12-15 at 08 40 24" src="https://github.com/nashaofu/screenshots-rs/assets/480806/240523a1-a4c0-4469-8327-fd957bd0100f">

